### PR TITLE
Support AWS IAM authentication for ECR image pulls

### DIFF
--- a/.github/workflows/pr-check-with-pylint.yml
+++ b/.github/workflows/pr-check-with-pylint.yml
@@ -44,9 +44,11 @@ jobs:
           
       - name: Create Boost Python symlink
         run: |
-          sudo ln -s \
-            "/usr/lib/x86_64-linux-gnu/libboost_python${PYVER}.so" \
-            "/usr/lib/x86_64-linux-gnu/libboost_python312.so"
+          if [ ! -e "/usr/lib/x86_64-linux-gnu/libboost_python312.so" ]; then
+            sudo ln -s \
+              "/usr/lib/x86_64-linux-gnu/libboost_python${PYVER}.so" \
+              "/usr/lib/x86_64-linux-gnu/libboost_python312.so"
+          fi
 
       - name: Install pylint and requirements
         run: |

--- a/agent/worker/docker_utils.py
+++ b/agent/worker/docker_utils.py
@@ -6,7 +6,7 @@ import json
 import re
 from enum import Enum
 import time
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from supervisely.app import DialogWindowError
 from supervisely.task.progress import Progress
@@ -131,10 +131,50 @@ def resolve_auth(registry: str, logger) -> Optional[Dict]:
     (~/.docker/config.json or $DOCKER_CONFIG) and credential helpers,
     the same way the docker CLI does.
     """
+    return resolve_auth_candidates(registry, logger)[0]
+
+
+def resolve_auth_candidates(registry: str, logger) -> List[Optional[Dict]]:
     auth = _registry_auth_from_env(registry)
     if auth is not None:
-        return auth
-    return _registry_auth_from_aws(registry, logger)
+        return [auth]
+
+    auth = _registry_auth_from_aws(registry, logger)
+    if auth is not None:
+        return [auth, None]
+    return [None]
+
+
+def _run_with_auth_fallback(operation, auth_candidates, logger):
+    from docker.errors import DockerException
+
+    try:
+        return operation(auth_candidates[0])
+    except DockerException as e:
+        if len(auth_candidates) == 1:
+            raise
+        logger.warning(
+            "Docker registry request with AWS IAM credentials failed, "
+            "falling back to the Docker config file",
+            extra={"error": str(e)},
+        )
+        return operation(auth_candidates[1])
+
+
+def _iter_with_auth_fallback(operation, auth_candidates, logger):
+    from docker.errors import DockerException
+
+    try:
+        yield from operation(auth_candidates[0])
+    except DockerException as e:
+        if len(auth_candidates) == 1:
+            raise
+        logger.warning(
+            "Docker registry request with AWS IAM credentials failed, "
+            "falling back to the Docker config file",
+            extra={"error": str(e)},
+        )
+        yield from operation(auth_candidates[1])
 
 
 def docker_pull_if_needed(docker_api, docker_image_name, policy, logger, progress=True):
@@ -206,9 +246,10 @@ def _docker_pull(docker_api, docker_image_name, logger, raise_exception=True):
 
     logger.info("Docker image will be pulled", extra={"image_name": docker_image_name})
     registry = resolve_registry(docker_image_name)
-    auth = resolve_auth(registry, logger)
+    auth_candidates = resolve_auth_candidates(registry, logger)
     logger.debug(
-        "Docker registry auth", extra={"registry": registry, "auth": _hide_credentials(auth)}
+        "Docker registry auth",
+        extra={"registry": registry, "auth": _hide_credentials(auth_candidates[0])},
     )
     for i in range(0, PULL_RETRIES + 1):
         retry_str = f" (retry {i}/{PULL_RETRIES})" if i > 0 else ""
@@ -219,8 +260,12 @@ def _docker_pull(docker_api, docker_image_name, logger, raise_exception=True):
         )
         progress_dummy.iter_done_report()
         try:
-
-            pulled_img = docker_api.images.pull(docker_image_name, auth_config=auth)
+            attempt_auth_candidates = auth_candidates if i == 0 else auth_candidates[:1]
+            pulled_img = _run_with_auth_fallback(
+                lambda auth: docker_api.images.pull(docker_image_name, auth_config=auth),
+                attempt_auth_candidates,
+                logger,
+            )
             logger.info(
                 "Docker image has been pulled",
                 extra={"pulled": {"tags": pulled_img.tags, "id": pulled_img.id}},
@@ -249,9 +294,10 @@ def _docker_pull_progress(docker_api, docker_image_name, logger, raise_exception
     from docker.errors import DockerException
 
     registry = resolve_registry(docker_image_name)
-    auth = resolve_auth(registry, logger)
+    auth_candidates = resolve_auth_candidates(registry, logger)
     logger.debug(
-        "Docker registry auth", extra={"registry": registry, "auth": _hide_credentials(auth)}
+        "Docker registry auth",
+        extra={"registry": registry, "auth": _hide_credentials(auth_candidates[0])},
     )
     for i in range(0, PULL_RETRIES + 1):
         try:
@@ -283,9 +329,15 @@ def _docker_pull_progress(docker_api, docker_image_name, logger, raise_exception
                 ext_logger=logger,
             )
 
-            for line in docker_api.api.pull(
-                docker_image_name, stream=True, decode=True, auth_config=auth
-            ):
+            attempt_auth_candidates = auth_candidates if i == 0 else auth_candidates[:1]
+            lines = _iter_with_auth_fallback(
+                lambda auth: docker_api.api.pull(
+                    docker_image_name, stream=True, decode=True, auth_config=auth
+                ),
+                attempt_auth_candidates,
+                logger,
+            )
+            for line in lines:
                 status = PullStatus.from_str(line.get("status", None))
                 layer_id = line.get("id", None)
                 progress_details = line.get("progressDetail", {})

--- a/agent/worker/docker_utils.py
+++ b/agent/worker/docker_utils.py
@@ -145,36 +145,49 @@ def resolve_auth_candidates(registry: str, logger) -> List[Optional[Dict]]:
     return [None]
 
 
-def _run_with_auth_fallback(operation, auth_candidates, logger):
+def _is_auth_error(e) -> bool:
+    from docker.errors import APIError
+
+    if isinstance(e, APIError) and e.status_code in (401, 403):
+        return True
+    # the daemon wraps registry auth errors into a 500 APIError, so the
+    # original status code is only recoverable from the message
+    msg = str(e).lower()
+    return any(
+        marker in msg
+        for marker in (
+            "unauthorized",
+            "denied",
+            "not authorized",
+            "authentication required",
+            "no basic auth credentials",
+        )
+    )
+
+
+def _run_with_auth_fallback(operation, auth_candidates, registry, logger):
+    """Run operation(auth) with each candidate in order.
+
+    Moves to the next candidate only when the registry rejected the current
+    credentials; any other error is raised immediately. Needed for the case
+    when IAM credentials can issue an ECR token but have no access to the
+    repository itself, while the Docker config file holds working credentials.
+    """
     from docker.errors import DockerException
 
-    try:
-        return operation(auth_candidates[0])
-    except DockerException as e:
-        if len(auth_candidates) == 1:
-            raise
-        logger.warning(
-            "Docker registry request with AWS IAM credentials failed, "
-            "falling back to the Docker config file",
-            extra={"error": str(e)},
-        )
-        return operation(auth_candidates[1])
-
-
-def _iter_with_auth_fallback(operation, auth_candidates, logger):
-    from docker.errors import DockerException
-
-    try:
-        yield from operation(auth_candidates[0])
-    except DockerException as e:
-        if len(auth_candidates) == 1:
-            raise
-        logger.warning(
-            "Docker registry request with AWS IAM credentials failed, "
-            "falling back to the Docker config file",
-            extra={"error": str(e)},
-        )
-        yield from operation(auth_candidates[1])
+    last = len(auth_candidates) - 1
+    for idx, auth in enumerate(auth_candidates):
+        try:
+            return operation(auth)
+        except DockerException as e:
+            if idx == last or not _is_auth_error(e):
+                raise
+            _ecr_auth_cache.pop(registry, None)
+            logger.warning(
+                "Docker registry rejected AWS IAM credentials, "
+                "retrying with credentials from the Docker config file",
+                extra={"registry": registry, "error": str(e)},
+            )
 
 
 def docker_pull_if_needed(docker_api, docker_image_name, policy, logger, progress=True):
@@ -260,10 +273,10 @@ def _docker_pull(docker_api, docker_image_name, logger, raise_exception=True):
         )
         progress_dummy.iter_done_report()
         try:
-            attempt_auth_candidates = auth_candidates if i == 0 else auth_candidates[:1]
             pulled_img = _run_with_auth_fallback(
                 lambda auth: docker_api.images.pull(docker_image_name, auth_config=auth),
-                attempt_auth_candidates,
+                auth_candidates,
+                registry,
                 logger,
             )
             logger.info(
@@ -300,7 +313,11 @@ def _docker_pull_progress(docker_api, docker_image_name, logger, raise_exception
         extra={"registry": registry, "auth": _hide_credentials(auth_candidates[0])},
     )
     for i in range(0, PULL_RETRIES + 1):
-        try:
+        retry_str = f" (retry {i}/{PULL_RETRIES})" if i > 0 else ""
+
+        # progress state is created inside so that a fallback retry with other
+        # credentials starts reporting from scratch instead of double-counting
+        def _pull_and_report(auth, retry_str=retry_str):
             layers_total_load = {}
             layers_current_load = {}
             layers_total_extract = {}
@@ -308,8 +325,6 @@ def _docker_pull_progress(docker_api, docker_image_name, logger, raise_exception
             started = set()
             loaded = set()
             pulled = set()
-
-            retry_str = f" (retry {i}/{PULL_RETRIES})" if i > 0 else ""
 
             progress_full = Progress(
                 "Preparing dockerimage" + retry_str,
@@ -329,15 +344,9 @@ def _docker_pull_progress(docker_api, docker_image_name, logger, raise_exception
                 ext_logger=logger,
             )
 
-            attempt_auth_candidates = auth_candidates if i == 0 else auth_candidates[:1]
-            lines = _iter_with_auth_fallback(
-                lambda auth: docker_api.api.pull(
-                    docker_image_name, stream=True, decode=True, auth_config=auth
-                ),
-                attempt_auth_candidates,
-                logger,
-            )
-            for line in lines:
+            for line in docker_api.api.pull(
+                docker_image_name, stream=True, decode=True, auth_config=auth
+            ):
                 status = PullStatus.from_str(line.get("status", None))
                 layer_id = line.get("id", None)
                 progress_details = line.get("progressDetail", {})
@@ -388,6 +397,9 @@ def _docker_pull_progress(docker_api, docker_image_name, logger, raise_exception
 
             progress_full.iter_done()
             progress_full.report_progress()
+
+        try:
+            _run_with_auth_fallback(_pull_and_report, auth_candidates, registry, logger)
             logger.info("Docker image has been pulled", extra={"image_name": docker_image_name})
             return
         except DockerException as e:

--- a/agent/worker/docker_utils.py
+++ b/agent/worker/docker_utils.py
@@ -1,7 +1,9 @@
 # coding: utf-8
 from __future__ import annotations
 
+import base64
 import json
+import re
 from enum import Enum
 import time
 from typing import Dict, Optional
@@ -55,6 +57,8 @@ def _auths_from_env() -> Dict:
     doc_regs = constants.DOCKER_REGISTRY().split(",")
     auths = {}
     for login, pasw, reg in zip(doc_logs, doc_pasws, doc_regs):
+        if reg == "" or (login == "" and pasw == ""):
+            continue
         auths.update({reg: {"username": login, "password": pasw}})
     return auths
 
@@ -62,6 +66,75 @@ def _auths_from_env() -> Dict:
 def _registry_auth_from_env(registry: str) -> Dict:
     auths = _auths_from_env()
     return auths.get(registry, None)
+
+
+_ECR_REGISTRY_RE = re.compile(
+    r"^\d{12}\.dkr\.ecr(?:-fips)?\.(?P<region>[a-z0-9-]+)\.(?:amazonaws\.com(?:\.cn)?|sc2s\.sgov\.gov|c2s\.ic\.gov)$"
+)
+# ECR tokens are valid for 12 hours; refresh a bit earlier to avoid using
+# a token that expires mid-pull
+_ECR_TOKEN_EXPIRATION_MARGIN = 15 * 60
+_ecr_auth_cache = {}
+
+
+def _registry_auth_from_aws(registry: str, logger) -> Optional[Dict]:
+    match = _ECR_REGISTRY_RE.match(registry)
+    if match is None:
+        return None
+
+    cached = _ecr_auth_cache.get(registry)
+    if cached is not None and cached[0] > time.time():
+        return cached[1]
+
+    try:
+        import boto3
+    except ImportError:
+        logger.warning(
+            "Image is hosted on AWS ECR, but boto3 is not installed; "
+            "AWS IAM authentication is not available",
+            extra={"registry": registry},
+        )
+        return None
+
+    try:
+        ecr_client = boto3.client("ecr", region_name=match.group("region"))
+        auth_data = ecr_client.get_authorization_token()["authorizationData"][0]
+        username, password = (
+            base64.b64decode(auth_data["authorizationToken"]).decode("utf-8").split(":", 1)
+        )
+        auth = {"username": username, "password": password}
+        expires_at = auth_data["expiresAt"].timestamp() - _ECR_TOKEN_EXPIRATION_MARGIN
+        _ecr_auth_cache[registry] = (expires_at, auth)
+        logger.info(
+            "Got ECR authorization token using AWS IAM credentials",
+            extra={"registry": registry},
+        )
+        return auth
+    except Exception as e:
+        logger.warning(
+            "Unable to get ECR authorization token using AWS IAM credentials, "
+            "falling back to the Docker config file. If the agent host uses an EC2 "
+            "instance role, make sure the instance metadata service is reachable "
+            "from containers (IMDSv2 hop limit >= 2), or provide AWS credentials "
+            "to the agent container via environment variables or a mounted ~/.aws.",
+            extra={"registry": registry, "error": str(e)},
+        )
+        return None
+
+
+def resolve_auth(registry: str, logger) -> Optional[Dict]:
+    """Resolve pull credentials for the registry.
+
+    Priority: explicit DOCKER_LOGIN/DOCKER_PASSWORD/DOCKER_REGISTRY credentials,
+    then AWS IAM credentials for ECR registries. Returns None when nothing
+    matched, so that docker-py falls back to the Docker config file
+    (~/.docker/config.json or $DOCKER_CONFIG) and credential helpers,
+    the same way the docker CLI does.
+    """
+    auth = _registry_auth_from_env(registry)
+    if auth is not None:
+        return auth
+    return _registry_auth_from_aws(registry, logger)
 
 
 def docker_pull_if_needed(docker_api, docker_image_name, policy, logger, progress=True):
@@ -133,9 +206,10 @@ def _docker_pull(docker_api, docker_image_name, logger, raise_exception=True):
 
     logger.info("Docker image will be pulled", extra={"image_name": docker_image_name})
     registry = resolve_registry(docker_image_name)
-    auth = _registry_auth_from_env(registry)
-    auth_log = hidden_auth().get(registry, None)
-    logger.debug("Docker registry auth", extra={"registry": registry, "auth": auth_log})
+    auth = resolve_auth(registry, logger)
+    logger.debug(
+        "Docker registry auth", extra={"registry": registry, "auth": _hide_credentials(auth)}
+    )
     for i in range(0, PULL_RETRIES + 1):
         retry_str = f" (retry {i}/{PULL_RETRIES})" if i > 0 else ""
         progress_dummy = Progress(
@@ -175,9 +249,10 @@ def _docker_pull_progress(docker_api, docker_image_name, logger, raise_exception
     from docker.errors import DockerException
 
     registry = resolve_registry(docker_image_name)
-    auth = _registry_auth_from_env(registry)
-    auth_log = hidden_auth().get(registry, None)
-    logger.debug("Docker registry auth", extra={"registry": registry, "auth": auth_log})
+    auth = resolve_auth(registry, logger)
+    logger.debug(
+        "Docker registry auth", extra={"registry": registry, "auth": _hide_credentials(auth)}
+    )
     for i in range(0, PULL_RETRIES + 1):
         try:
             layers_total_load = {}
@@ -291,14 +366,20 @@ def _docker_image_exists(docker_api, docker_image_name):
     return True
 
 
+def _hide_credentials(auth: Optional[Dict]) -> Optional[Dict]:
+    if auth is None:
+        return None
+
+    def mask(value):
+        if not value:
+            return value
+        return value[0] + ("*" * (len(value) - 2))[:10] + value[-1]
+
+    return {"username": mask(auth.get("username")), "password": mask(auth.get("password"))}
+
+
 def hidden_auth():
     auths = _auths_from_env()
     for registry, auth in auths.items():
-        username = auth.get("username")
-        if username:
-            username = username[0] + ("*" * (len(username) - 2))[:10] + username[-1]
-        password = auth.get("password")
-        if password:
-            password = password[0] + ("*" * (len(password) - 2))[:10] + password[-1]
-        auths[registry] = {"username": username, "password": password}
+        auths[registry] = _hide_credentials(auth)
     return auths

--- a/agent/worker/task_update.py
+++ b/agent/worker/task_update.py
@@ -141,6 +141,7 @@ def check_and_pull_sly_net_if_needed(
     docker_registry_image_info = docker_utils._run_with_auth_fallback(
         lambda auth: ic.get_registry_data(sly_net_client_image_name, auth_config=auth),
         auth_candidates,
+        registry,
         logger,
     )
     name_with_digest: str = cur_container.image.attrs.get("RepoDigests", [""])[0]

--- a/agent/worker/task_update.py
+++ b/agent/worker/task_update.py
@@ -137,9 +137,12 @@ def check_and_pull_sly_net_if_needed(
         sly_net_client_image_name = cur_container.attrs["Config"]["Image"]
 
     registry = docker_utils.resolve_registry(sly_net_client_image_name)
-    auth = docker_utils.resolve_auth(registry, logger)
-
-    docker_registry_image_info = ic.get_registry_data(sly_net_client_image_name, auth_config=auth)
+    auth_candidates = docker_utils.resolve_auth_candidates(registry, logger)
+    docker_registry_image_info = docker_utils._run_with_auth_fallback(
+        lambda auth: ic.get_registry_data(sly_net_client_image_name, auth_config=auth),
+        auth_candidates,
+        logger,
+    )
     name_with_digest: str = cur_container.image.attrs.get("RepoDigests", [""])[0]
 
     if name_with_digest.endswith(docker_registry_image_info.id):

--- a/agent/worker/task_update.py
+++ b/agent/worker/task_update.py
@@ -137,7 +137,7 @@ def check_and_pull_sly_net_if_needed(
         sly_net_client_image_name = cur_container.attrs["Config"]["Image"]
 
     registry = docker_utils.resolve_registry(sly_net_client_image_name)
-    auth = docker_utils._registry_auth_from_env(registry)
+    auth = docker_utils.resolve_auth(registry, logger)
 
     docker_registry_image_info = ic.get_registry_data(sly_net_client_image_name, auth_config=auth)
     name_with_digest: str = cur_container.image.attrs.get("RepoDigests", [""])[0]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ python-slugify==6.1.2
 nvidia-ml-py==12.535.77
 httpx>=0.26.0
 filelock==3.13.1
+boto3>=1.34.0,<2 # AWS IAM authentication for pulling images from ECR
 
 # grpcio installed from system packages (python3-grpcio)
 # grpcio-tools removed due to protobuf version conflict with supervisely[agent]

--- a/tests/test_ecr_auth.py
+++ b/tests/test_ecr_auth.py
@@ -58,7 +58,7 @@ def test_docker_pull_falls_back_from_aws_to_docker_config(monkeypatch):
     )
     pulled_image = Mock(tags=["repo:tag"], id="sha256:image")
     docker_api = Mock()
-    docker_api.images.pull.side_effect = [DockerException("IAM denied"), pulled_image]
+    docker_api.images.pull.side_effect = [DockerException("pull access denied"), pulled_image]
 
     docker_utils._docker_pull(docker_api, "repo:tag", Mock())
 
@@ -66,6 +66,43 @@ def test_docker_pull_falls_back_from_aws_to_docker_config(monkeypatch):
         call("repo:tag", auth_config=ECR_AUTH),
         call("repo:tag", auth_config=None),
     ]
+
+
+def test_docker_pull_does_not_fallback_on_non_auth_error(monkeypatch):
+    monkeypatch.setattr(docker_utils, "Progress", _Progress)
+    monkeypatch.setattr(docker_utils, "resolve_registry", lambda image: ECR_REGISTRY)
+    monkeypatch.setattr(
+        docker_utils, "resolve_auth_candidates", lambda registry, logger: [ECR_AUTH, None]
+    )
+    monkeypatch.setattr(docker_utils.time, "sleep", lambda delay: None)
+    pulled_image = Mock(tags=["repo:tag"], id="sha256:image")
+    docker_api = Mock()
+    docker_api.images.pull.side_effect = [DockerException("read timeout"), pulled_image]
+
+    docker_utils._docker_pull(docker_api, "repo:tag", Mock())
+
+    # a transient error must be handled by the retry loop with the same
+    # credentials, not by silently switching to the Docker config
+    assert docker_api.images.pull.call_args_list == [
+        call("repo:tag", auth_config=ECR_AUTH),
+        call("repo:tag", auth_config=ECR_AUTH),
+    ]
+
+
+def test_auth_error_fallback_invalidates_ecr_token_cache(monkeypatch):
+    monkeypatch.setattr(docker_utils, "Progress", _Progress)
+    monkeypatch.setattr(docker_utils, "resolve_registry", lambda image: ECR_REGISTRY)
+    monkeypatch.setattr(
+        docker_utils, "resolve_auth_candidates", lambda registry, logger: [ECR_AUTH, None]
+    )
+    monkeypatch.setitem(docker_utils._ecr_auth_cache, ECR_REGISTRY, (float("inf"), ECR_AUTH))
+    pulled_image = Mock(tags=["repo:tag"], id="sha256:image")
+    docker_api = Mock()
+    docker_api.images.pull.side_effect = [DockerException("pull access denied"), pulled_image]
+
+    docker_utils._docker_pull(docker_api, "repo:tag", Mock())
+
+    assert ECR_REGISTRY not in docker_utils._ecr_auth_cache
 
 
 def test_docker_pull_progress_falls_back_from_aws_to_docker_config(monkeypatch):

--- a/tests/test_ecr_auth.py
+++ b/tests/test_ecr_auth.py
@@ -1,0 +1,141 @@
+import os
+from unittest.mock import Mock, call
+
+from docker.errors import DockerException
+
+os.environ.setdefault("ACCESS_TOKEN", "test-token")
+
+from worker import constants  # noqa: F401 - initializes worker imports in the expected order
+from worker import docker_utils
+
+
+ECR_REGISTRY = "123456789012.dkr.ecr.us-east-1.amazonaws.com"
+ECR_AUTH = {"username": "AWS", "password": "iam-token"}
+
+
+class _Progress:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def iter_done_report(self):
+        pass
+
+    def iter_done(self):
+        pass
+
+    def report_progress(self):
+        pass
+
+
+def test_resolve_auth_candidates_does_not_fallback_from_explicit_credentials(monkeypatch):
+    explicit_auth = {"username": "user", "password": "password"}
+    monkeypatch.setattr(docker_utils, "_registry_auth_from_env", lambda registry: explicit_auth)
+    aws_auth = Mock()
+    monkeypatch.setattr(docker_utils, "_registry_auth_from_aws", aws_auth)
+
+    candidates = docker_utils.resolve_auth_candidates(ECR_REGISTRY, Mock())
+
+    assert candidates == [explicit_auth]
+    aws_auth.assert_not_called()
+
+
+def test_resolve_auth_candidates_adds_docker_config_after_aws(monkeypatch):
+    monkeypatch.setattr(docker_utils, "_registry_auth_from_env", lambda registry: None)
+    monkeypatch.setattr(
+        docker_utils, "_registry_auth_from_aws", lambda registry, logger: ECR_AUTH
+    )
+
+    candidates = docker_utils.resolve_auth_candidates(ECR_REGISTRY, Mock())
+
+    assert candidates == [ECR_AUTH, None]
+
+
+def test_docker_pull_falls_back_from_aws_to_docker_config(monkeypatch):
+    monkeypatch.setattr(docker_utils, "Progress", _Progress)
+    monkeypatch.setattr(docker_utils, "resolve_registry", lambda image: ECR_REGISTRY)
+    monkeypatch.setattr(
+        docker_utils, "resolve_auth_candidates", lambda registry, logger: [ECR_AUTH, None]
+    )
+    pulled_image = Mock(tags=["repo:tag"], id="sha256:image")
+    docker_api = Mock()
+    docker_api.images.pull.side_effect = [DockerException("IAM denied"), pulled_image]
+
+    docker_utils._docker_pull(docker_api, "repo:tag", Mock())
+
+    assert docker_api.images.pull.call_args_list == [
+        call("repo:tag", auth_config=ECR_AUTH),
+        call("repo:tag", auth_config=None),
+    ]
+
+
+def test_docker_pull_progress_falls_back_from_aws_to_docker_config(monkeypatch):
+    monkeypatch.setattr(docker_utils, "Progress", _Progress)
+    monkeypatch.setattr(docker_utils, "resolve_registry", lambda image: ECR_REGISTRY)
+    monkeypatch.setattr(
+        docker_utils, "resolve_auth_candidates", lambda registry, logger: [ECR_AUTH, None]
+    )
+    docker_api = Mock()
+
+    def failed_stream():
+        yield from ()
+        raise DockerException("IAM denied")
+
+    docker_api.api.pull.side_effect = [failed_stream(), iter(())]
+
+    docker_utils._docker_pull_progress(docker_api, "repo:tag", Mock())
+
+    assert docker_api.api.pull.call_args_list == [
+        call("repo:tag", stream=True, decode=True, auth_config=ECR_AUTH),
+        call("repo:tag", stream=True, decode=True, auth_config=None),
+    ]
+
+
+def test_docker_pull_retries_aws_after_failed_docker_config_fallback(monkeypatch):
+    monkeypatch.setattr(docker_utils, "Progress", _Progress)
+    monkeypatch.setattr(docker_utils, "resolve_registry", lambda image: ECR_REGISTRY)
+    monkeypatch.setattr(
+        docker_utils, "resolve_auth_candidates", lambda registry, logger: [ECR_AUTH, None]
+    )
+    monkeypatch.setattr(docker_utils.time, "sleep", lambda delay: None)
+    pulled_image = Mock(tags=["repo:tag"], id="sha256:image")
+    docker_api = Mock()
+    docker_api.images.pull.side_effect = [
+        DockerException("IAM denied"),
+        DockerException("Docker config denied"),
+        pulled_image,
+    ]
+
+    docker_utils._docker_pull(docker_api, "repo:tag", Mock())
+
+    assert docker_api.images.pull.call_args_list == [
+        call("repo:tag", auth_config=ECR_AUTH),
+        call("repo:tag", auth_config=None),
+        call("repo:tag", auth_config=ECR_AUTH),
+    ]
+
+
+def test_registry_data_falls_back_from_aws_to_docker_config(monkeypatch):
+    from worker import task_update
+
+    monkeypatch.setattr(docker_utils, "resolve_registry", lambda image: ECR_REGISTRY)
+    monkeypatch.setattr(
+        docker_utils, "resolve_auth_candidates", lambda registry, logger: [ECR_AUTH, None]
+    )
+    registry_data = Mock(id="sha256:image")
+    image_collection = Mock()
+    image_collection.get_registry_data.side_effect = [
+        DockerException("IAM denied"),
+        registry_data,
+    ]
+    monkeypatch.setattr(task_update, "ImageCollection", lambda docker_client: image_collection)
+    container = Mock()
+    container.attrs = {"Config": {"Image": "repo:tag"}}
+    container.image.attrs = {"RepoDigests": ["repo@sha256:image"]}
+
+    updated = task_update.check_and_pull_sly_net_if_needed(Mock(), container, Mock())
+
+    assert updated is False
+    assert image_collection.get_registry_data.call_args_list == [
+        call("repo:tag", auth_config=ECR_AUTH),
+        call("repo:tag", auth_config=None),
+    ]


### PR DESCRIPTION
## Problem

The agent resolved registry credentials **only** from `DOCKER_LOGIN` / `DOCKER_PASSWORD` / `DOCKER_REGISTRY` (env vars or agent options from the instance UI). Any authentication configured on the host — e.g. the Amazon ECR credential helper used by the docker CLI — was never picked up, because pull authentication in Docker is always client-side (`X-Registry-Auth` header) and the agent is a separate docker-py client running inside its own container. As a result, `docker pull` worked on the host while the agent failed to pull the same ECR image.

## Solution

All image pulls (`_docker_pull`, `_docker_pull_progress`, net-client update check) now go through a single resolver `docker_utils.resolve_auth(registry, logger)`.

## Credential resolution order

1. **Explicit credentials** from `DOCKER_LOGIN` / `DOCKER_PASSWORD` / `DOCKER_REGISTRY` (env or agent options). If the image registry is listed there, these credentials are used — existing setups keep working unchanged.
2. **AWS IAM for ECR.** If the registry matches an ECR hostname (`<account>.dkr.ecr.<region>.amazonaws.com`, incl. FIPS / China / GovCloud endpoints), the agent obtains an authorization token via `boto3` using the standard AWS credential chain: EC2 instance role (IMDS), `AWS_*` env vars, or a mounted `~/.aws`. Tokens are cached per registry and refreshed 15 minutes before expiration.
3. **Docker config fallback.** If neither matched, `auth_config=None` is passed to docker-py, which then resolves credentials from the Docker config file (`~/.docker/config.json` or `$DOCKER_CONFIG`) and credential helpers — the same way the docker CLI does. Mounting a config file into the agent container is enough for static `docker login` credentials.
4. **Anonymous pull** when nothing above yields credentials (public registries).

If the AWS token request fails (e.g. IMDS unreachable from containers — IMDSv2 hop limit must be ≥ 2), the agent logs a warning with a hint and falls through to step 3 instead of failing the pull.

## Other changes

- Empty `DOCKER_*` values no longer produce a bogus `"": {...}` auth entry.
- Credentials are masked in debug logs regardless of their source (new `_hide_credentials` helper).
- New dependency: `boto3` (imported lazily, only when the image is hosted on ECR).