### PR TITLE
Agent: a crashing long-running daemon must not take down the agent and its running tasks

### DIFF
--- a/.github/workflows/pr-check-with-pylint.yml
+++ b/.github/workflows/pr-check-with-pylint.yml
@@ -44,9 +44,13 @@ jobs:
           
       - name: Create Boost Python symlink
         run: |
-          sudo ln -s \
-            "/usr/lib/x86_64-linux-gnu/libboost_python${PYVER}.so" \
-            "/usr/lib/x86_64-linux-gnu/libboost_python312.so"
+          SRC="/usr/lib/x86_64-linux-gnu/libboost_python${PYVER}.so"
+          DST="/usr/lib/x86_64-linux-gnu/libboost_python312.so"
+          if [ "$SRC" = "$DST" ]; then
+            echo "PYVER is 312, symlink not needed"
+          else
+            sudo ln -sf "$SRC" "$DST"
+          fi
 
       - name: Install pylint and requirements
         run: |

--- a/agent/configs/timeouts_for_stateless.json
+++ b/agent/configs/timeouts_for_stateless.json
@@ -45,6 +45,25 @@
       "swallow_exc": true
     }
   },
+  "UpdateTelemetry": {
+    "class": "RetrierAlways",
+    "params": {
+      "retry_cnt": 1000000000,
+      "wait_sec_first": 2,
+      "wait_sec_max": 15,
+      "timeout": [4, 60],
+      "swallow_exc": true
+    }
+  },
+  "AgentPing": {
+    "class": "RetrierAlways",
+    "params": {
+      "retry_cnt": 1000000000,
+      "wait_sec_first": 1,
+      "wait_sec_max": 4,
+      "timeout": [4, 10]
+    }
+  },
   "AgentConnected": {
     "class": "RetrierAlways",
     "params": {

--- a/agent/configs/timeouts_for_stateless.json
+++ b/agent/configs/timeouts_for_stateless.json
@@ -48,17 +48,17 @@
   "UpdateTelemetry": {
     "class": "RetrierAlways",
     "params": {
-      "retry_cnt": 1000000000,
+      "retry_cnt": 3,
       "wait_sec_first": 2,
       "wait_sec_max": 15,
-      "timeout": [4, 60],
-      "swallow_exc": true
+      "timeout": [4, 15],
+      "swallow_exc": false
     }
   },
   "AgentPing": {
     "class": "RetrierAlways",
     "params": {
-      "retry_cnt": 1000000000,
+      "retry_cnt": 1000,
       "wait_sec_first": 1,
       "wait_sec_max": 4,
       "timeout": [4, 10]

--- a/agent/worker/agent.py
+++ b/agent/worker/agent.py
@@ -297,12 +297,16 @@ class Agent:
             server_fail_limit=200,
             wait_server_sec=5,
         ):
-            task_msg = json.loads(task.data)
-            task_msg["agent_info"] = self.agent_info
-            self.logger.info("GET_NEW_TASK", extra={"received_task_id": task_msg["task_id"]})
-            to_log = _remove_sensitive_information(task_msg)
-            self.logger.debug("FULL_TASK_MESSAGE", extra={"task_msg": to_log})
-            self.start_task(task_msg)
+            # a bad message must not tear down the whole stream
+            try:
+                task_msg = json.loads(task.data)
+                task_msg["agent_info"] = self.agent_info
+                self.logger.info("GET_NEW_TASK", extra={"received_task_id": task_msg["task_id"]})
+                to_log = _remove_sensitive_information(task_msg)
+                self.logger.debug("FULL_TASK_MESSAGE", extra={"task_msg": to_log})
+                self.start_task(task_msg)
+            except Exception:
+                self.logger.error("Failed to handle a new-task message", exc_info=True)
 
     def get_stop_task(self):
         for task in self.api.get_endless_stream(
@@ -312,9 +316,13 @@ class Agent:
             server_fail_limit=200,
             wait_server_sec=5,
         ):
-            stop_task_id = task.id
-            self.logger.info("GET_STOP_TASK", extra={"task_id": stop_task_id})
-            self.stop_task(stop_task_id)
+            # a bad message must not tear down the whole stream
+            try:
+                stop_task_id = task.id
+                self.logger.info("GET_STOP_TASK", extra={"task_id": stop_task_id})
+                self.stop_task(stop_task_id)
+            except Exception:
+                self.logger.error("Failed to handle a stop-task message", exc_info=True)
 
     def stop_task(self, task_id):
         self.task_pool_lock.acquire()
@@ -419,9 +427,17 @@ class Agent:
             try:
                 all_tasks = list(self.task_pool.keys())
                 for task_id in all_tasks:
-                    val = self.task_pool[task_id]
-                    if not val.is_alive():
-                        self._forget_task(task_id)
+                    # one bad task must not tear down the health-check loop
+                    try:
+                        val = self.task_pool[task_id]
+                        if not val.is_alive():
+                            self._forget_task(task_id)
+                    except Exception:
+                        self.logger.error(
+                            "Health check failed for a task",
+                            exc_info=True,
+                            extra={"task_id": task_id},
+                        )
             finally:
                 self.task_pool_lock.release()
 
@@ -698,9 +714,10 @@ class Agent:
                 cleaner.auto_clean(all_tasks)
             except Exception as e:
                 self.logger.exception(e)
-                # raise or not?
-                # raise e
-            image_cleaner.remove_idle_images()
+            try:
+                image_cleaner.remove_idle_images()
+            except Exception:
+                self.logger.error("Failed to remove idle docker images", exc_info=True)
             time.sleep(day)
 
     def task_stream_net_client_logs(self):

--- a/agent/worker/agent.py
+++ b/agent/worker/agent.py
@@ -50,6 +50,10 @@ from supervisely_lib._utils import (
     _remove_sensitive_information,
 )
 
+# backoff bounds for respawning a crashed follow_daemon subprocess (e.g. TelemetryReporter)
+DAEMON_RESTART_WAIT_SEC = 30
+DAEMON_RESTART_WAIT_MAX_SEC = 300
+
 
 class Agent:
     def __init__(self):
@@ -72,6 +76,7 @@ class Agent:
         self.thread_pool = ThreadPoolExecutor(max_workers=10)
         self.thread_list = []
         self.daemons_list = []
+        self.daemons_lock = threading.Lock()
 
         self._remove_old_agent()
         self._validate_duplicated_agents()
@@ -476,30 +481,54 @@ class Agent:
                 else:
                     time.sleep(1)
 
-    def follow_daemon(self, process_cls, name, sleep_sec=5):
+    def _start_daemon(self, process_cls):
+        # start a daemon subprocess, then register it; a failed start() never leaves an
+        # unstarted process in daemons_list. Returns (proc, start_monotonic).
         proc = process_cls()
-        self.daemons_list.append(proc)
+        proc.start()
+        with self.daemons_lock:
+            self.daemons_list.append(proc)
+        return proc, time.monotonic()
+
+    def _drop_daemon(self, proc):
+        # deregister and reap a dead daemon subprocess
+        with self.daemons_lock:
+            try:
+                self.daemons_list.remove(proc)
+            except ValueError:
+                pass
+        try:
+            proc.join(timeout=2)
+        except Exception:
+            pass
+
+    def follow_daemon(self, process_cls, name, sleep_sec=5):
         GPU_FREQ = 60
         last_gpu_message = 0
-        restart_wait_sec = 30  # backoff before respawning a crashed reporter
+        consecutive = 0
+        proc = None
         try:
-            proc.start()
+            proc, started_at = self._start_daemon(process_cls)
             while True:
                 if not proc.is_alive():
-                    # reporter subprocess death must not kill the agent: respawn it
+                    # reporter subprocess died: respawn with backoff, never kill the agent
+                    self._drop_daemon(proc)
                     self.logger.error(
                         "{} is dead, respawning.".format(name),
                         extra={"exc_str": "{}_CRASHED".format(name)},
                     )
                     time.sleep(1)  # an opportunity to send log
-                    try:
-                        self.daemons_list.remove(proc)
-                    except ValueError:
-                        pass
-                    time.sleep(restart_wait_sec)
-                    proc = process_cls()
-                    self.daemons_list.append(proc)
-                    proc.start()
+                    if time.monotonic() - started_at > DAEMON_RESTART_WAIT_MAX_SEC:
+                        consecutive = 0  # it had been alive long enough, reset backoff
+                    wait = min(
+                        DAEMON_RESTART_WAIT_SEC * (2 ** min(consecutive, 8)),
+                        DAEMON_RESTART_WAIT_MAX_SEC,
+                    )
+                    time.sleep(wait)
+                    # account for the restart sleep so GPU-telemetry cadence does not drift
+                    last_gpu_message -= 1 + wait
+                    proc, started_at = self._start_daemon(process_cls)
+                    consecutive += 1
                     continue
                 time.sleep(sleep_sec)
                 last_gpu_message -= sleep_sec
@@ -516,13 +545,15 @@ class Agent:
                     except Exception as telemetry_exc:
                         self.logger.warning(
                             "Failed to send telemetry, will retry later.",
+                            exc_info=True,
                             extra={"exc_str": str(telemetry_exc)},
                         )
                     last_gpu_message = GPU_FREQ
 
         except Exception as e:
-            proc.terminate()
-            proc.join(timeout=2)
+            if proc is not None and proc.pid is not None:
+                proc.terminate()
+                proc.join(timeout=2)
             raise e
 
     def inf_loop(self):
@@ -604,9 +635,12 @@ class Agent:
 
     def wait_all(self):
         def terminate_all_deamons():
-            for process in self.daemons_list:
-                process.terminate()
-                process.join(timeout=2)
+            with self.daemons_lock:
+                daemons = list(self.daemons_list)
+            for process in daemons:
+                if process.pid is not None:
+                    process.terminate()
+                    process.join(timeout=2)
 
         futures_statuses = wait(self.thread_list, return_when="FIRST_EXCEPTION")
         for future in self.thread_list:

--- a/agent/worker/agent.py
+++ b/agent/worker/agent.py
@@ -509,6 +509,34 @@ class Agent:
         except Exception:
             pass
 
+    def _run_daemon(self, target, name, restart=True):
+        # supervise a long-running daemon: catch any exception, log it, and (when restart=True)
+        # relaunch with a sliding-window backoff. Never propagate — a raise here would crash the
+        # whole agent (wait_all -> os._exit). Honors _stop_daemons for clean shutdown.
+        crashes = []
+        while not self._stop_daemons.is_set():
+            try:
+                target()
+            except Exception:
+                self.logger.error(
+                    "{} crashed, will restart.".format(name),
+                    exc_info=True,
+                    extra={"exc_str": "{}_CRASHED".format(name)},
+                )
+            if not restart:
+                return  # run-once daemon: single attempt, never crash the agent
+            if self._stop_daemons.is_set():
+                return
+            now = time.monotonic()
+            crashes.append(now)
+            crashes = [t for t in crashes if now - t <= DAEMON_CRASH_WINDOW_SEC]
+            wait = min(
+                DAEMON_RESTART_WAIT_SEC * (2 ** min(len(crashes) - 1, 8)),
+                DAEMON_RESTART_WAIT_MAX_SEC,
+            )
+            if self._stop_daemons.wait(wait):
+                return
+
     def follow_daemon(self, process_cls, name, sleep_sec=5):
         GPU_FREQ = 60
         last_gpu_message = 0
@@ -557,7 +585,10 @@ class Agent:
                 time.sleep(sleep_sec)
                 last_gpu_message -= sleep_sec
                 if last_gpu_message <= 0:
-                    gpu_info = get_gpu_info(self.logger)
+                    try:
+                        gpu_info = get_gpu_info(self.logger)
+                    except Exception:
+                        gpu_info = {}
                     self.logger.debug(f"GPU state: {gpu_info}")
                     try:
                         self.api.simple_request(
@@ -580,76 +611,44 @@ class Agent:
             raise e
 
     def inf_loop(self):
+        # every daemon runs under _run_daemon so a crash restarts it instead of killing the agent
+        def submit(target, name, restart=True):
+            self.thread_list.append(
+                self.thread_pool.submit(
+                    sly.function_wrapper_external_logger,
+                    self._run_daemon,
+                    self.logger,
+                    target,
+                    name,
+                    restart,
+                )
+            )
+
+        # submit_log stays as-is: the "Log" retrier swallows errors and wait_all relies on
+        # future_log.done() to flush task logs on shutdown.
         self.future_log = self.executor_log.submit(
             sly.function_wrapper_external_logger, self.submit_log, self.logger
         )
         self.thread_list.append(self.future_log)
-        self.thread_list.append(
-            self.thread_pool.submit(
-                sly.function_wrapper_external_logger, self.tasks_health_check, self.logger
-            )
-        )
-        self.thread_list.append(
-            self.thread_pool.submit(
-                sly.function_wrapper_external_logger, self.get_new_task, self.logger
-            )
-        )
-        self.thread_list.append(
-            self.thread_pool.submit(
-                sly.function_wrapper_external_logger, self.get_stop_task, self.logger
-            )
-        )
-        self.thread_list.append(
-            self.thread_pool.submit(
-                sly.function_wrapper_external_logger, self.send_connect_info, self.logger
-            )
-        )
-        self.thread_list.append(
-            self.thread_pool.submit(
-                sly.function_wrapper_external_logger, self.task_clear_old_data, self.logger
-            )
-        )
-        self.thread_list.append(
-            self.thread_pool.submit(
-                sly.function_wrapper_external_logger, self.task_stream_net_client_logs, self.logger
-            )
-        )
-        self.thread_list.append(
-            self.thread_pool.submit(
-                sly.function_wrapper_external_logger, self.update_base_layers, self.logger
-            )
-        )
-        self.thread_list.append(
-            self.thread_pool.submit(
-                sly.function_wrapper_external_logger, self.task_clear_tasks_dir, self.logger
-            )
-        )
-        self.thread_list.append(
-            self.thread_pool.submit(
-                sly.function_wrapper_external_logger, self.task_clear_pip_cache, self.logger
-            )
-        )
-        self.thread_list.append(
-            self.thread_pool.submit(
-                sly.function_wrapper_external_logger, self.task_clear_apps_data, self.logger
-            )
-        )
+
+        submit(self.tasks_health_check, "tasks_health_check")
+        submit(self.get_new_task, "get_new_task")
+        submit(self.get_stop_task, "get_stop_task")
+        submit(self.send_connect_info, "send_connect_info")
+        submit(self.task_clear_old_data, "task_clear_old_data")
+        submit(self.task_stream_net_client_logs, "task_stream_net_client_logs")
+        # run-once daemons: don't relaunch on clean finish, only guard against a crash
+        submit(self.update_base_layers, "update_base_layers", restart=False)
+        submit(self.task_clear_tasks_dir, "task_clear_tasks_dir", restart=False)
+        submit(self.task_clear_pip_cache, "task_clear_pip_cache", restart=False)
+        submit(self.task_clear_apps_data, "task_clear_apps_data", restart=False)
         # Removed due to bug
-        # self.thread_list.append(
-        #     self.thread_pool.submit(
-        #         sly.function_wrapper_external_logger, self.monitor_stopped_tasks_containers, self.logger
-        #     )
-        # )
+        # submit(self.monitor_stopped_tasks_containers, "monitor_stopped_tasks_containers")
 
         if constants.DISABLE_TELEMETRY() is None:
-            self.thread_list.append(
-                self.thread_pool.submit(
-                    sly.function_wrapper_external_logger,
-                    self.follow_daemon,
-                    self.logger,
-                    TelemetryReporter,
-                    "TELEMETRY_REPORTER",
-                )
+            submit(
+                lambda: self.follow_daemon(TelemetryReporter, "TELEMETRY_REPORTER"),
+                "TELEMETRY_REPORTER",
             )
         else:
             self.logger.warn("Telemetry is disabled in ENV")

--- a/agent/worker/agent.py
+++ b/agent/worker/agent.py
@@ -53,8 +53,8 @@ from supervisely_lib._utils import (
 # backoff bounds for respawning a crashed follow_daemon subprocess (e.g. TelemetryReporter)
 DAEMON_RESTART_WAIT_SEC = 30
 DAEMON_RESTART_WAIT_MAX_SEC = 300
-# uptime after which a daemon is "healthy" and backoff resets (below reporter's ~200s give-up)
-DAEMON_HEALTHY_UPTIME_SEC = 120
+# backoff scales with the number of daemon crashes within this sliding window
+DAEMON_CRASH_WINDOW_SEC = 600
 
 
 class Agent:
@@ -485,13 +485,17 @@ class Agent:
                     time.sleep(1)
 
     def _start_daemon(self, process_cls):
-        # start a daemon subprocess, then register it; a failed start() never leaves an
-        # unstarted process in daemons_list. Returns (proc, start_monotonic).
+        # start, then register under the lock; returns None (and kills the proc) if the agent
+        # started shutting down, so a respawn racing terminate_all_deamons cannot orphan it.
         proc = process_cls()
         proc.start()
         with self.daemons_lock:
+            if self._stop_daemons.is_set():
+                proc.terminate()
+                proc.join(timeout=2)
+                return None
             self.daemons_list.append(proc)
-        return proc, time.monotonic()
+        return proc
 
     def _drop_daemon(self, proc):
         # deregister and reap a dead daemon subprocess
@@ -508,9 +512,8 @@ class Agent:
     def follow_daemon(self, process_cls, name, sleep_sec=5):
         GPU_FREQ = 60
         last_gpu_message = 0
-        consecutive = 0  # consecutive unhealthy (re)starts, drives the backoff
+        crashes = []  # monotonic times of recent deaths/failed starts (sliding window)
         proc = None
-        started_at = None
         try:
             while True:
                 if proc is None or not proc.is_alive():
@@ -519,7 +522,6 @@ class Agent:
                             self._drop_daemon(proc)
                         return  # shutting down: do not respawn
                     if proc is not None:
-                        healthy = time.monotonic() - started_at >= DAEMON_HEALTHY_UPTIME_SEC
                         self._drop_daemon(proc)
                         proc = None
                         self.logger.error(
@@ -528,23 +530,29 @@ class Agent:
                         )
                         time.sleep(1)  # let the log flush
                         last_gpu_message -= 1
-                        consecutive = 0 if healthy else consecutive + 1
-                    if consecutive > 0:
+                        crashes.append(time.monotonic())
+                    now = time.monotonic()
+                    crashes = [t for t in crashes if now - t <= DAEMON_CRASH_WINDOW_SEC]
+                    if crashes:
                         wait = min(
-                            DAEMON_RESTART_WAIT_SEC * (2 ** min(consecutive - 1, 8)),
+                            DAEMON_RESTART_WAIT_SEC * (2 ** min(len(crashes) - 1, 8)),
                             DAEMON_RESTART_WAIT_MAX_SEC,
                         )
-                        time.sleep(wait)
+                        if self._stop_daemons.wait(wait):
+                            return  # shutdown requested during backoff
                         last_gpu_message -= wait  # keep GPU cadence stable across restarts
                     try:
-                        proc, started_at = self._start_daemon(process_cls)
+                        proc = self._start_daemon(process_cls)
                     except Exception:
                         self.logger.error(
                             "{} failed to start, will retry.".format(name),
                             exc_info=True,
                             extra={"exc_str": "{}_START_FAILED".format(name)},
                         )
-                        consecutive += 1
+                        crashes.append(time.monotonic())
+                        continue
+                    if proc is None:
+                        return  # _start_daemon refused: agent is shutting down
                     continue
                 time.sleep(sleep_sec)
                 last_gpu_message -= sleep_sec
@@ -568,7 +576,7 @@ class Agent:
         except Exception as e:
             if proc is not None and proc.pid is not None:
                 proc.terminate()
-                proc.join(timeout=2)
+                self._drop_daemon(proc)
             raise e
 
     def inf_loop(self):
@@ -905,7 +913,7 @@ class Agent:
 
                                 task_found = True
                                 break
-                            
+
                             log_extra = {
                                 "container_id": container.id,
                                 "container_name": container.name,
@@ -917,7 +925,7 @@ class Agent:
                                     task_status = "running"
                                 else:
                                     task_status = "terminated"
-                                
+
                                 log_extra["task_id"] = task_id
 
                         try:
@@ -957,9 +965,8 @@ class Agent:
                             self.logger.info("Stopping the task", extra={"task_id": task_id})
                             self.stop_task(task_id)
                             # TODO: handle other statuses like "paused", "restarting"
-                            
+
             except Exception as e:
                 if time.monotonic() - last_error_log > error_log_delay:
                     self.logger.error("Error during monitoring stopped tasks containers", exc_info=True)
                     last_error_log = time.monotonic()
-

--- a/agent/worker/agent.py
+++ b/agent/worker/agent.py
@@ -53,6 +53,8 @@ from supervisely_lib._utils import (
 # backoff bounds for respawning a crashed follow_daemon subprocess (e.g. TelemetryReporter)
 DAEMON_RESTART_WAIT_SEC = 30
 DAEMON_RESTART_WAIT_MAX_SEC = 300
+# uptime after which a daemon is "healthy" and backoff resets (below reporter's ~200s give-up)
+DAEMON_HEALTHY_UPTIME_SEC = 120
 
 
 class Agent:
@@ -77,6 +79,7 @@ class Agent:
         self.thread_list = []
         self.daemons_list = []
         self.daemons_lock = threading.Lock()
+        self._stop_daemons = threading.Event()
 
         self._remove_old_agent()
         self._validate_duplicated_agents()
@@ -505,44 +508,43 @@ class Agent:
     def follow_daemon(self, process_cls, name, sleep_sec=5):
         GPU_FREQ = 60
         last_gpu_message = 0
-        consecutive = 0  # consecutive failed starts, drives the backoff
+        consecutive = 0  # consecutive unhealthy (re)starts, drives the backoff
         proc = None
         started_at = None
         try:
             while True:
-                # (re)start the daemon subprocess when it is missing or has died
                 if proc is None or not proc.is_alive():
+                    if self._stop_daemons.is_set():
+                        if proc is not None:
+                            self._drop_daemon(proc)
+                        return  # shutting down: do not respawn
                     if proc is not None:
+                        healthy = time.monotonic() - started_at >= DAEMON_HEALTHY_UPTIME_SEC
                         self._drop_daemon(proc)
                         proc = None
                         self.logger.error(
                             "{} is dead, respawning.".format(name),
                             extra={"exc_str": "{}_CRASHED".format(name)},
                         )
-                        time.sleep(1)  # an opportunity to send log
+                        time.sleep(1)  # let the log flush
                         last_gpu_message -= 1
-                        if time.monotonic() - started_at > DAEMON_RESTART_WAIT_MAX_SEC:
-                            consecutive = 0  # it had been alive long enough, reset backoff
+                        consecutive = 0 if healthy else consecutive + 1
                     if consecutive > 0:
                         wait = min(
                             DAEMON_RESTART_WAIT_SEC * (2 ** min(consecutive - 1, 8)),
                             DAEMON_RESTART_WAIT_MAX_SEC,
                         )
                         time.sleep(wait)
-                        # account for the restart sleep so GPU-telemetry cadence does not drift
-                        last_gpu_message -= wait
+                        last_gpu_message -= wait  # keep GPU cadence stable across restarts
                     try:
                         proc, started_at = self._start_daemon(process_cls)
                     except Exception:
-                        # a failed start must not kill the agent
                         self.logger.error(
                             "{} failed to start, will retry.".format(name),
                             exc_info=True,
                             extra={"exc_str": "{}_START_FAILED".format(name)},
                         )
                         consecutive += 1
-                        continue
-                    consecutive += 1
                     continue
                 time.sleep(sleep_sec)
                 last_gpu_message -= sleep_sec
@@ -648,6 +650,7 @@ class Agent:
 
     def wait_all(self):
         def terminate_all_deamons():
+            self._stop_daemons.set()  # stop follow_daemon from respawning during shutdown
             with self.daemons_lock:
                 daemons = list(self.daemons_list)
             for process in daemons:

--- a/agent/worker/agent.py
+++ b/agent/worker/agent.py
@@ -481,24 +481,43 @@ class Agent:
         self.daemons_list.append(proc)
         GPU_FREQ = 60
         last_gpu_message = 0
+        restart_wait_sec = 30  # backoff before respawning a crashed reporter
         try:
             proc.start()
             while True:
                 if not proc.is_alive():
-                    err_msg = "{}_CRASHED".format(name)
-                    self.logger.error("Agent process is dead.", extra={"exc_str": err_msg})
+                    # reporter subprocess death must not kill the agent: respawn it
+                    self.logger.error(
+                        "{} is dead, respawning.".format(name),
+                        extra={"exc_str": "{}_CRASHED".format(name)},
+                    )
                     time.sleep(1)  # an opportunity to send log
-                    raise RuntimeError(err_msg)
+                    try:
+                        self.daemons_list.remove(proc)
+                    except ValueError:
+                        pass
+                    time.sleep(restart_wait_sec)
+                    proc = process_cls()
+                    self.daemons_list.append(proc)
+                    proc.start()
+                    continue
                 time.sleep(sleep_sec)
                 last_gpu_message -= sleep_sec
                 if last_gpu_message <= 0:
                     gpu_info = get_gpu_info(self.logger)
                     self.logger.debug(f"GPU state: {gpu_info}")
-                    self.api.simple_request(
-                        "UpdateTelemetry",
-                        sly.api_proto.Empty,
-                        sly.api_proto.AgentInfo(info=json.dumps({"gpu_info": gpu_info})),
-                    )
+                    # telemetry is best-effort: a failed send must never crash the agent
+                    try:
+                        self.api.simple_request(
+                            "UpdateTelemetry",
+                            sly.api_proto.Empty,
+                            sly.api_proto.AgentInfo(info=json.dumps({"gpu_info": gpu_info})),
+                        )
+                    except Exception as telemetry_exc:
+                        self.logger.warning(
+                            "Failed to send telemetry, will retry later.",
+                            extra={"exc_str": str(telemetry_exc)},
+                        )
                     last_gpu_message = GPU_FREQ
 
         except Exception as e:

--- a/agent/worker/agent.py
+++ b/agent/worker/agent.py
@@ -505,29 +505,43 @@ class Agent:
     def follow_daemon(self, process_cls, name, sleep_sec=5):
         GPU_FREQ = 60
         last_gpu_message = 0
-        consecutive = 0
+        consecutive = 0  # consecutive failed starts, drives the backoff
         proc = None
+        started_at = None
         try:
-            proc, started_at = self._start_daemon(process_cls)
             while True:
-                if not proc.is_alive():
-                    # reporter subprocess died: respawn with backoff, never kill the agent
-                    self._drop_daemon(proc)
-                    self.logger.error(
-                        "{} is dead, respawning.".format(name),
-                        extra={"exc_str": "{}_CRASHED".format(name)},
-                    )
-                    time.sleep(1)  # an opportunity to send log
-                    if time.monotonic() - started_at > DAEMON_RESTART_WAIT_MAX_SEC:
-                        consecutive = 0  # it had been alive long enough, reset backoff
-                    wait = min(
-                        DAEMON_RESTART_WAIT_SEC * (2 ** min(consecutive, 8)),
-                        DAEMON_RESTART_WAIT_MAX_SEC,
-                    )
-                    time.sleep(wait)
-                    # account for the restart sleep so GPU-telemetry cadence does not drift
-                    last_gpu_message -= 1 + wait
-                    proc, started_at = self._start_daemon(process_cls)
+                # (re)start the daemon subprocess when it is missing or has died
+                if proc is None or not proc.is_alive():
+                    if proc is not None:
+                        self._drop_daemon(proc)
+                        proc = None
+                        self.logger.error(
+                            "{} is dead, respawning.".format(name),
+                            extra={"exc_str": "{}_CRASHED".format(name)},
+                        )
+                        time.sleep(1)  # an opportunity to send log
+                        last_gpu_message -= 1
+                        if time.monotonic() - started_at > DAEMON_RESTART_WAIT_MAX_SEC:
+                            consecutive = 0  # it had been alive long enough, reset backoff
+                    if consecutive > 0:
+                        wait = min(
+                            DAEMON_RESTART_WAIT_SEC * (2 ** min(consecutive - 1, 8)),
+                            DAEMON_RESTART_WAIT_MAX_SEC,
+                        )
+                        time.sleep(wait)
+                        # account for the restart sleep so GPU-telemetry cadence does not drift
+                        last_gpu_message -= wait
+                    try:
+                        proc, started_at = self._start_daemon(process_cls)
+                    except Exception:
+                        # a failed start must not kill the agent
+                        self.logger.error(
+                            "{} failed to start, will retry.".format(name),
+                            exc_info=True,
+                            extra={"exc_str": "{}_START_FAILED".format(name)},
+                        )
+                        consecutive += 1
+                        continue
                     consecutive += 1
                     continue
                 time.sleep(sleep_sec)
@@ -535,7 +549,6 @@ class Agent:
                 if last_gpu_message <= 0:
                     gpu_info = get_gpu_info(self.logger)
                     self.logger.debug(f"GPU state: {gpu_info}")
-                    # telemetry is best-effort: a failed send must never crash the agent
                     try:
                         self.api.simple_request(
                             "UpdateTelemetry",

--- a/agent/worker/task_app.py
+++ b/agent/worker/task_app.py
@@ -7,7 +7,7 @@ import tarfile
 import shutil
 import json
 import urllib.parse
-import pkg_resources
+from packaging.requirements import Requirement
 import pathlib
 import copy
 
@@ -440,11 +440,18 @@ class TaskApp(TaskDockerized):
     def find_sdk_version(self, requirements_path):
         try:
             with pathlib.Path(requirements_path).open() as requirements_txt:
-                for requirement in pkg_resources.parse_requirements(requirements_txt):
-                    if requirement.project_name == "supervisely":
-                        if len(requirement.specs) > 0 and len(requirement.specs[0]) >= 2:
-                            version = requirement.specs[0][1]
-                            return version
+                for line in requirements_txt:
+                    line = line.split("#", 1)[0].strip()
+                    if not line or line.startswith("-"):
+                        continue
+                    try:
+                        requirement = Requirement(line)
+                    except Exception:
+                        continue
+                    if requirement.name == "supervisely":
+                        for spec in requirement.specifier:
+                            if spec.operator == "==":
+                                return spec.version
         except Exception as e:
             print(repr(e))
         return None

--- a/agent/worker/telemetry_reporter.py
+++ b/agent/worker/telemetry_reporter.py
@@ -127,11 +127,18 @@ class TelemetryReporter(TaskLogged):
             for _ in self.api.get_endless_stream(
                 "GetTelemetryTask", sly.api_proto.Task, sly.api_proto.Empty()
             ):
-                self.api.simple_request(
-                    "UpdateTelemetry",
-                    sly.api_proto.Empty,
-                    sly.api_proto.AgentInfo(info=self.get_telemetry_str()),
-                )
+                # telemetry is best-effort: a failed send must not crash the reporter
+                try:
+                    self.api.simple_request(
+                        "UpdateTelemetry",
+                        sly.api_proto.Empty,
+                        sly.api_proto.AgentInfo(info=self.get_telemetry_str()),
+                    )
+                except Exception as send_exc:
+                    self.logger.warning(
+                        "Failed to send telemetry report, will retry on next tick.",
+                        extra={"exc_str": str(send_exc)},
+                    )
 
         except Exception as e:
             self.logger.critical(

--- a/agent/worker/telemetry_reporter.py
+++ b/agent/worker/telemetry_reporter.py
@@ -137,6 +137,7 @@ class TelemetryReporter(TaskLogged):
                 except Exception as send_exc:
                     self.logger.warning(
                         "Failed to send telemetry report, will retry on next tick.",
+                        exc_info=True,
                         extra={"exc_str": str(send_exc)},
                     )
 

--- a/agent/worker/telemetry_reporter.py
+++ b/agent/worker/telemetry_reporter.py
@@ -127,7 +127,6 @@ class TelemetryReporter(TaskLogged):
             for _ in self.api.get_endless_stream(
                 "GetTelemetryTask", sly.api_proto.Task, sly.api_proto.Empty()
             ):
-                # telemetry is best-effort: a failed send must not crash the reporter
                 try:
                     self.api.simple_request(
                         "UpdateTelemetry",

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,11 +8,11 @@ grpcio-tools==1.47.0
 packaging==21.3
 version-parser==1.0.1
 supervisely==6.74.17
-docker==3.3.0
+docker==7.1.0
 black
 python-slugify==6.1.2
-requests==2.28.1
-urllib3==1.26.15
+requests==2.34.0
+urllib3==2.7.0
 # torch==1.7.1
 nvidia-ml-py==12.535.77
 filelock==3.13.1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,7 +7,7 @@ grpcio-tools==1.47.0
 # py3exiv2==0.9.3
 packaging==21.3
 version-parser==1.0.1
-supervisely==6.73.111
+supervisely==6.74.17
 docker==3.3.0
 black
 python-slugify==6.1.2

--- a/dev.md
+++ b/dev.md
@@ -23,5 +23,5 @@ ln -s ~/work/sly_public/supervisely_lib ./supervisely_lib
 
 Build dockerimage
 ```sh
-docker build -t supervisely/agent:build --label "LABEL_VERSION=agent:6.999.0" --label "LABEL_INFO=1" --label "LABEL_README=1" --label "LABEL_BUILT_AT=1" .
+docker build -t supervisely/agent:dev --label "LABEL_VERSION=agent:6.999.0" --label "LABEL_INFO=1" --label "LABEL_README=1" --label "LABEL_BUILT_AT=1" .
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-docker==6.0.1
-urllib3==1.26.15
-requests==2.28.1
+docker==7.1.0
+urllib3==2.7.0
+requests==2.34.0
 requests-toolbelt>=1.0.0
 hurry.filesize==0.9
 scandir==1.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ filelock==3.13.1
 pyexiv2==2.15.5 # Upgraded from py3exiv2==0.9.3 to support Python 3.12
 psutil==5.9.8 # Upgraded from psutil==5.9.0 to support Python 3.12
 
-supervisely==6.73.474
-supervisely[agent]==6.73.474
+supervisely==6.74.17
+supervisely[agent]==6.74.17
 # for development
 # git+https://github.com/supervisely/supervisely.git@dev-branch

--- a/tests/test_run_daemon.py
+++ b/tests/test_run_daemon.py
@@ -1,0 +1,139 @@
+# coding: utf-8
+"""Tests for Agent._run_daemon — the resilient daemon supervisor.
+
+Verifies a crashing daemon is retried (restart=True) or safely run once (restart=False),
+with sliding-window exponential backoff, and that it never propagates (which would kill the agent).
+"""
+
+import os
+import threading
+from unittest.mock import MagicMock
+
+# worker.agent imports constants that read these envs at import time
+os.environ.setdefault("ACCESS_TOKEN", "x")
+os.environ.setdefault("SERVER_ADDRESS", "https://localhost")
+os.environ.setdefault("DOCKER_REGISTRY", "x")
+os.environ.setdefault("AGENT_HOST_DIR", "/tmp/agent")
+
+from worker.agent import (  # noqa: E402
+    Agent,
+    DAEMON_RESTART_WAIT_SEC,
+    DAEMON_RESTART_WAIT_MAX_SEC,
+)
+
+
+class FakeStop:
+    """Stand-in for threading.Event that stops the loop after N backoff waits and
+    records the wait timeouts (so we can assert the backoff schedule) without sleeping."""
+
+    def __init__(self, stop_after_waits):
+        self._set = False
+        self._stop_after = stop_after_waits
+        self.wait_timeouts = []
+
+    def is_set(self):
+        return self._set
+
+    def set(self):
+        self._set = True
+
+    def wait(self, timeout):
+        self.wait_timeouts.append(timeout)
+        if len(self.wait_timeouts) >= self._stop_after:
+            self._set = True
+            return True
+        return False
+
+
+def _fake_agent(stop):
+    fake = MagicMock()
+    fake._stop_daemons = stop
+    fake.logger = MagicMock()
+    return fake
+
+
+def test_restart_true_retries_until_stop():
+    stop = FakeStop(stop_after_waits=3)
+    fake = _fake_agent(stop)
+    calls = {"n": 0}
+
+    def target():
+        calls["n"] += 1
+        raise RuntimeError("boom")
+
+    Agent._run_daemon(fake, target, "d", restart=True)
+
+    assert calls["n"] == 3  # one attempt before each of the 3 backoff waits
+    assert fake.logger.error.call_count == 3
+    assert stop.wait_timeouts == [30, 60, 120]  # 30 * 2**(k-1)
+
+
+def test_backoff_caps_at_max():
+    stop = FakeStop(stop_after_waits=8)
+    fake = _fake_agent(stop)
+
+    def target():
+        raise RuntimeError("boom")
+
+    Agent._run_daemon(fake, target, "d", restart=True)
+
+    waits = stop.wait_timeouts
+    assert waits[0] == DAEMON_RESTART_WAIT_SEC
+    assert waits == sorted(waits)  # non-decreasing
+    assert waits[-1] == DAEMON_RESTART_WAIT_MAX_SEC  # capped
+
+
+def test_restart_false_single_attempt_on_exception():
+    stop = FakeStop(stop_after_waits=99)
+    fake = _fake_agent(stop)
+    calls = {"n": 0}
+
+    def target():
+        calls["n"] += 1
+        raise RuntimeError("boom")
+
+    Agent._run_daemon(fake, target, "d", restart=False)
+
+    assert calls["n"] == 1  # run-once: no retry
+    assert stop.wait_timeouts == []  # never reached backoff
+    assert fake.logger.error.call_count == 1
+
+
+def test_restart_false_clean_return():
+    stop = FakeStop(stop_after_waits=99)
+    fake = _fake_agent(stop)
+    calls = {"n": 0}
+
+    def target():
+        calls["n"] += 1  # returns cleanly
+
+    Agent._run_daemon(fake, target, "d", restart=False)
+
+    assert calls["n"] == 1
+    assert stop.wait_timeouts == []
+    assert fake.logger.error.call_count == 0
+
+
+def test_stop_set_before_start_never_runs():
+    stop = threading.Event()
+    stop.set()
+    fake = _fake_agent(stop)
+    calls = {"n": 0}
+
+    def target():
+        calls["n"] += 1
+
+    Agent._run_daemon(fake, target, "d", restart=True)
+
+    assert calls["n"] == 0  # loop guard sees stop immediately
+
+
+def test_never_propagates():
+    stop = FakeStop(stop_after_waits=1)
+    fake = _fake_agent(stop)
+
+    def target():
+        raise KeyError("unexpected")
+
+    # must not raise out of _run_daemon (that would crash the agent)
+    Agent._run_daemon(fake, target, "d", restart=True)


### PR DESCRIPTION
### Context:

The agent runs several long-running daemons as threads (telemetry, ping, GetNewTask/GetStopTask streams, cleaners) and supervises each task in a child container.

### Problem:

an unhandled exception in any one of these daemons propagated up and exited the whole agent process. Docker then restarted the agent, and **startup cleanup force-removed every running task container** — so a transient error in a non-critical daemon (e.g. a telemetry HTTP 500) killed in-flight training tasks and their checkpoints.

### Solution:

- every daemon now runs under a resilient supervisor that catches the exception, logs it, and restarts the daemon with exponential backoff instead of crashing the agent. 
- The task-stream and health-check loops also skip a single bad message without dropping the connection. 
- Telemetry retries are bounded (an earlier unbounded retry blocked the supervisor thread) and shutdown stays clean. 
