### PR TITLE
fix(net): pass WireGuard endpoint to sly-net-client only when explicitly overridden

### DIFF
--- a/agent/main.py
+++ b/agent/main.py
@@ -82,8 +82,20 @@ def _start_net_client(docker_api=None):
         command = [
             constants.TOKEN(),
             urljoin(constants.SERVER_ADDRESS(), "net/"),
-            constants.NET_SERVER_ADDRESS(),
         ]
+
+        # The 3rd argument is an endpoint OVERRIDE for sly-net-client: it only falls back
+        # to the endpoint returned by the server on registration when the argument is empty.
+        # Pass it only when it was explicitly configured, otherwise the server-side endpoint
+        # can never take effect.
+        net_server_address = constants.NET_SERVER_ADDRESS()
+        if net_server_address:
+            command.append(net_server_address)
+        else:
+            sly.logger.info(
+                f"{constants._NET_SERVER_ADDRESS} is not set, "
+                "sly-net-client will use the endpoint provided by the server"
+            )
         envs = [
             f"{constants._SLY_NET_CLIENT_PING_INTERVAL}={constants.SLY_NET_CLIENT_PING_INTERVAL()}",
             f"{constants._TRUST_DOWNSTREAM_PROXY}={constants.TRUST_DOWNSTREAM_PROXY()}",

--- a/agent/worker/constants.py
+++ b/agent/worker/constants.py
@@ -220,12 +220,17 @@ def SERVER_ADDRESS():
 
 
 def NET_SERVER_ADDRESS():
+    """Explicitly configured WireGuard endpoint for sly-net-client, or None.
+
+    Returns a value only when NET_SERVER_ADDRESS is actually set — either by the
+    server via netClientOptions.netServerAddress, or directly by an operator on
+    the agent container. When it is unset (or empty) the agent must NOT invent an
+    endpoint: it is passed to sly-net-client as an override, and any value there
+    suppresses the endpoint the server returns on registration.
+    """
     str_url = os.environ.get(_NET_SERVER_ADDRESS, None)
     if str_url is None or str_url.strip() == "":
-        server_addr = SERVER_ADDRESS()
-        parsed_uri = urlparse(server_addr)
-        net_server_port = NET_SERVER_PORT()
-        return f"{parsed_uri.hostname}:{net_server_port}"
+        return None
 
     if ("http://" not in str_url) and ("https://" not in str_url):
         str_url = f"http://{str_url}"


### PR DESCRIPTION
## Problem

`_start_net_client` always passed the WireGuard endpoint as the **3rd positional argument** to `sly-net-client`:

```python
command = [
    constants.TOKEN(),
    urljoin(constants.SERVER_ADDRESS(), "net/"),
    constants.NET_SERVER_ADDRESS(),   # always present
]
```

That argument is an **override**. When it is empty, the client instead uses the endpoint the server hands it during registration.

`NET_SERVER_ADDRESS()` never returned an empty value — when the env var was unset it **synthesized** `<server hostname>:<NET_SERVER_PORT>` (default `51822`). Arg 3 was therefore always non-empty, the override was always in force, and the server-advertised endpoint could never take effect.

Consequence: changing the agent-facing endpoint requires recreating the net-client container on every host, rather than being a server-side setting.

## Change

- `constants.NET_SERVER_ADDRESS()` returns `None` when `NET_SERVER_ADDRESS` is unset or empty. When it *is* set, behaviour is unchanged, including the existing `http://`-prefixing normalization.
- `main._start_net_client` appends arg 3 only when that value is truthy, and logs when it is omitted.

"Explicitly overridden" still covers both legitimate paths:
- the server sending `netClientOptions.netServerAddress` via `GetAgentOptions` (`agent_utils.update_env_param(constants._NET_SERVER_ADDRESS, ...)`)
- an operator setting `NET_SERVER_ADDRESS` directly on the agent container

Only the agent-invented `hostname:NET_SERVER_PORT` fallback is dropped — that is what pins agents to a stale endpoint.

`main.py:_start_net_client` was the **only** caller of `NET_SERVER_ADDRESS()` (verified by grep over the whole repo), so no other consumer changes. The `NET_SERVER_PORT()` guard in `_start_net_client` is left untouched.

## Verification

No test covers this path; the repo's suite is `tests/clean_functions` + `tests/test_run_daemon.py` and is unrelated. Baseline and post-change `pytest` results are identical (`3 failed, 10 passed`; the 3 failures are pre-existing `FileNotFoundError: /sly_agent/apps_cache`, i.e. they expect an agent-container filesystem). `pylint` (what CI runs) scores `10.00/10` on both changed files.

The real `_start_net_client` was executed with a fake docker API to capture the actual `command`:

| `NET_SERVER_ADDRESS` | before | after |
|---|---|---|
| unset | `[…, '<server-host>:51822']` | 2 args, no override |
| `""` / whitespace | `[…, '<server-host>:51822']` | 2 args, no override |
| `vpn.example.com:51825` | `[…, 'vpn.example.com:51825']` | `[…, 'vpn.example.com:51825']` |
| `https://vpn.example.com:9999` | `[…, 'vpn.example.com:9999']` | `[…, 'vpn.example.com:9999']` |

## Notes for the reviewer

- **Not retroactive.** Agents that already have a baked arg 3 in their running net-client container keep using it; they still need one net-client recreation to adopt the new behaviour.
- **Omitting the argument is equivalent to passing an empty one.** Checked against the net-client entrypoint: it reads the argument once and does not run with `set -u`, so with two arguments it expands to the empty string and the override is simply not applied. Worth re-confirming against whichever image tag you deploy.
- Worth knowing: `git log -S` shows arg 3 has been unconditionally present since before `NET_SERVER_ADDRESS` was introduced (4db1a02, Sep 2024 — the pre-existing code synthesized the same `hostname:port` inline). The empty-arg path has effectively never been exercised by a released agent, so this is the first traffic through it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)